### PR TITLE
scripts: prefer `sh -eu`; canonicalise `$CWD`

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh -eu
 #
 # Copyright (c) 2015 Richard Mortier <mort@cantab.net>. All Rights Reserved.
 # Copyright (c) 2015 Thomas Gazagnaire <thomas@gazagnaire.org>.
@@ -15,7 +15,7 @@
 # OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 # PERFORMANCE OF THIS SOFTWARE.
 
-set -eu
+cd $(dirname "$(readlink -f "$0")") # canonicalise directory
 
 if [ "$#" -ne 1 ]; then
     echo "usage: $(basename "$0") NAME"

--- a/scripts/post-merge.hook
+++ b/scripts/post-merge.hook
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/sh -eu
 #
 # Copyright (c) 2015 Richard Mortier <mort@cantab.net>. All Rights Reserved.
 # Copyright (c) 2015 Thomas Gazagnaire <thomas@gazagnaire.org>.
@@ -21,6 +21,8 @@
 # exec 1<>LOG_FILE
 # exec 2>&1
 # echo "This line will appear in LOG_FILE, not 'on screen'"
+
+cd $(dirname "$(readlink -f "$0")") # canonicalise directory
 
 HTTP=tutorial.openmirage.org
 


### PR DESCRIPTION
This should mean that symlinking from `/etc/rc5.d/S10...` now works to cause sites to be restarted on host reboot.
